### PR TITLE
fix: use npx for TypeScript commands in build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "dev": "node esbuild.config.mjs",
-    "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+    "build": "npx tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "format": "prettier --write 'src/**/*.{ts,tsx}'",
@@ -29,7 +29,7 @@
     "version": "node version-bump.mjs && git add manifest.json versions.json",
     "clean": "rm -rf main.js main.js.map coverage .jest-cache",
     "clean:all": "npm run clean && rm -rf node_modules",
-    "typecheck": "tsc -noEmit",
+    "typecheck": "npx tsc -noEmit",
     "validate": "npm run lint && npm run typecheck && npm run test",
     "ci": "npm run validate && npm run build"
   },


### PR DESCRIPTION
This PR fixes the TypeScript compiler issue on Windows 11 where `tsc` command was not found.

## Changes
- Updated build script to use `npx tsc` instead of `tsc`
- Updated typecheck script to use `npx tsc` instead of `tsc`

This ensures TypeScript runs from local node_modules without requiring global installation.

Fixes #9

🤖 Generated with [Claude Code](https://claude.ai/code)