### PR TITLE
fix: Implement provider-specific file size limits for Deepgram

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -216,6 +216,21 @@ export default class SpeechToTextPlugin extends Plugin {
                 this.logger
             );
             
+            // Set provider-specific capabilities for file size limits
+            try {
+                const transcriber = this.transcriberFactory.getProvider(
+                    provider === 'auto' ? 'auto' : provider as any
+                );
+                const capabilities = transcriber.getCapabilities();
+                audioProcessor.setProviderCapabilities({ maxFileSize: capabilities.maxFileSize });
+                this.logger.info(`AudioProcessor configured with provider capabilities`, {
+                    provider: transcriber.getProviderName(),
+                    maxFileSize: capabilities.maxFileSize / 1024 / 1024 + 'MB'
+                });
+            } catch (error) {
+                this.logger.warn('Failed to get provider capabilities, using default limits', error as Error);
+            }
+            
             const textFormatter = new TextFormatter(this.settings);
             
             this.transcriptionService = new TranscriptionService(


### PR DESCRIPTION
Fixes issue where Deepgram provider was incorrectly limited to 25MB when it should support files up to 2GB.

## Changes
- Add setProviderCapabilities() method to AudioProcessor for dynamic file size limits
- Update main.ts to pass provider capabilities to AudioProcessor on initialization
- Deepgram now supports files up to 2GB (was limited to 25MB)
- Whisper maintains 25MB limit as expected
- Add comprehensive tests for provider-specific file size validation
- Improve error messages to show actual provider limits

Resolves #15

🤖 Generated with [Claude Code](https://claude.ai/code)