### PR TITLE
Fix Deepgram Speaker Diarization not working

### DIFF
--- a/src/infrastructure/api/TranscriberFactory.ts
+++ b/src/infrastructure/api/TranscriberFactory.ts
@@ -314,6 +314,7 @@ export class TranscriberFactory {
                 const deepgramAdapter = new DeepgramAdapter(
                     deepgramService,
                     this.logger,
+                    this.settingsManager,
                     this.config.deepgram
                 );
                 this.providers.set('deepgram', deepgramAdapter);

--- a/src/main.ts
+++ b/src/main.ts
@@ -136,7 +136,8 @@ export default class SpeechToTextPlugin extends Plugin {
                         deepgram: {
                             enabled: !!this.settings.deepgramApiKey,
                             apiKey: this.settings.deepgramApiKey,
-                            model: this.settings.deepgramModel || 'nova-2'
+                            model: this.settings.deepgramModel || 'nova-2',
+                            features: this.settings.transcription?.deepgram?.features
                         },
                         
                         abTest: {


### PR DESCRIPTION
Fixes issue #19 where the Speaker Diarization feature toggle in the UI was not being applied to actual Deepgram API calls.

## Changes
- Enhanced DeepgramAdapter to read UI feature settings
- Fixed main.ts factory settings manager to pass through features configuration
- Properly map UI settings to API parameters

Generated with [Claude Code](https://claude.ai/code)