### PR TITLE
feat: add support section to settings page

### DIFF
--- a/src/ui/settings/SettingsTab.ts
+++ b/src/ui/settings/SettingsTab.ts
@@ -78,7 +78,12 @@ export class SettingsTab extends PluginSettingTab {
             console.log('Creating Advanced section...');
             this.createAdvancedSection(containerEl);
             console.log('Advanced section created');
-            
+
+            // Support Section
+            console.log('Creating Support section...');
+            this.createSupportSection(containerEl);
+            console.log('Support section created');
+
             console.log('=== Settings tab rendered successfully ===');
             console.log('Total child elements:', containerEl.children.length);
             
@@ -516,7 +521,7 @@ export class SettingsTab extends PluginSettingTab {
 
     private createAdvancedSection(containerEl: HTMLElement): void {
         containerEl.createEl('h3', { text: 'Advanced Settings' });
-        
+
         // Enable cache
         new Setting(containerEl)
             .setName('Enable cache')
@@ -527,7 +532,7 @@ export class SettingsTab extends PluginSettingTab {
                     this.plugin.settings.enableCache = value;
                     await this.plugin.saveSettings();
                 }));
-        
+
         // Debug mode
         new Setting(containerEl)
             .setName('Debug mode')
@@ -537,12 +542,12 @@ export class SettingsTab extends PluginSettingTab {
                 .onChange(async (value) => {
                     this.plugin.settings.debugMode = value;
                     await this.plugin.saveSettings();
-                    
+
                     if (value) {
                         new Notice('Debug mode enabled. Check console for logs.');
                     }
                 }));
-        
+
         // Reset settings button
         new Setting(containerEl)
             .setName('Reset to defaults')
@@ -557,11 +562,35 @@ export class SettingsTab extends PluginSettingTab {
                         const { DEFAULT_SETTINGS } = await import('../../domain/models/Settings');
                         this.plugin.settings = { ...DEFAULT_SETTINGS };
                         await this.plugin.saveSettings();
-                        
+
                         // Refresh the display
                         this.display();
                         new Notice('Settings reset to defaults');
                     }
+                }));
+    }
+
+    private createSupportSection(containerEl: HTMLElement): void {
+        // 구분선 추가
+        containerEl.createEl('hr', { cls: 'speech-to-text-separator' });
+
+        containerEl.createEl('h3', { text: 'Support' });
+
+        // 감사 메시지
+        containerEl.createEl('p', {
+            text: 'Thank you for using Speech to Text! Your support helps keep this plugin free and actively maintained.',
+            cls: 'setting-item-description'
+        });
+
+        // Buy me a coffee 버튼
+        new Setting(containerEl)
+            .setName('Support Development')
+            .setDesc('If you find this plugin helpful, consider buying me a coffee ☕')
+            .addButton(button => button
+                .setButtonText('☕ Buy me a coffee')
+                .setCta()
+                .onClick(() => {
+                    window.open('https://buymeacoffee.com/asyouplz', '_blank');
                 }));
     }
 

--- a/styles.css
+++ b/styles.css
@@ -3,6 +3,13 @@
 /* Import settings styles */
 @import url('./src/ui/settings/settings.css');
 
+/* Support Section */
+.speech-to-text-separator {
+    margin: 2em 0 1.5em 0;
+    border: none;
+    border-top: 1px solid var(--background-modifier-border);
+}
+
 /* File Picker Modal */
 .speech-to-text-file-list {
     max-height: 400px;


### PR DESCRIPTION
## Summary
- Added a dedicated "Support" section at the bottom of the settings page
- Includes a "Buy me a coffee" button with CTA styling for user donations
- Added visual separator (hr) to distinguish the support section from settings
- Button opens https://buymeacoffee.com/asyouplz in a new tab

## Changes Made
- **src/ui/settings/SettingsTab.ts**
  - Added `createSupportSection()` method to render the support UI
  - Integrated support section call in `display()` method after Advanced Settings
  - Added thank you message and support button with proper Obsidian styling
  
- **styles.css**
  - Added `.speech-to-text-separator` class for visual separation
  - Styled with proper margins and border to match Obsidian theme

## User Experience
- Non-intrusive placement at the end of settings
- Clear call-to-action with ☕ emoji
- Maintains consistency with existing Obsidian UI patterns
- Opens link in new tab to avoid disrupting user's workflow

## Test Plan
- [ ] Open plugin settings
- [ ] Scroll to bottom and verify "Support" section is visible
- [ ] Verify separator line appears above the section
- [ ] Click "Buy me a coffee" button
- [ ] Confirm it opens https://buymeacoffee.com/asyouplz in new tab
- [ ] Test in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)