### PR TITLE
fix(ui): use lowercase openai key placeholders

### DIFF
--- a/src/ui/settings/SettingsTab.ts
+++ b/src/ui/settings/SettingsTab.ts
@@ -369,7 +369,7 @@ export class SettingsTab extends PluginSettingTab {
             .setName('OpenAI API key')
             .setDesc('Enter your OpenAI API key for Whisper transcription')
             .addText((text) => {
-                text.setPlaceholder('Sk-...')
+                text.setPlaceholder('sk-...')
                     .setValue(this.maskApiKey(this.plugin.settings.apiKey || ''))
                     .onChange(async (value) => {
                         if (value && !value.includes('*')) {

--- a/src/ui/settings/SimpleSettingsTab.ts
+++ b/src/ui/settings/SimpleSettingsTab.ts
@@ -65,7 +65,7 @@ export class SimpleSettingsTab extends PluginSettingTab {
                     .setDesc('Enter your OpenAI API key for Whisper')
                     .addText((text) =>
                         text
-                            .setPlaceholder('Sk-...')
+                            .setPlaceholder('sk-...')
                             .setValue(this.plugin.settings.apiKey || '')
                             .onChange(async (value) => {
                                 this.plugin.settings.apiKey = value;


### PR DESCRIPTION
## Summary
- change the OpenAI API key placeholders in the settings UI from `Sk-...` to `sk-...`
- keep the change intentionally minimal so the next merge produces a semantic-release patch version

## Test plan
- [x] npm run lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)