### PR TITLE
fix(ui): use lowercase openai key placeholders

### DIFF
--- a/src/ui/settings/SettingsTab.ts
+++ b/src/ui/settings/SettingsTab.ts
@@ -369,7 +369,7 @@ export class SettingsTab extends PluginSettingTab {
             .setName('OpenAI API key')
             .setDesc('Enter your OpenAI API key for Whisper transcription')
             .addText((text) => {
-                text.setPlaceholder('Sk-...')
+                text.setPlaceholder('sk-...')
                     .setValue(this.maskApiKey(this.plugin.settings.apiKey || ''))
                     .onChange(async (value) => {
                         if (value && !value.includes('*')) {

--- a/src/ui/settings/SimpleSettingsTab.ts
+++ b/src/ui/settings/SimpleSettingsTab.ts
@@ -65,7 +65,7 @@ export class SimpleSettingsTab extends PluginSettingTab {
                     .setDesc('Enter your OpenAI API key for Whisper')
                     .addText((text) =>
                         text
-                            .setPlaceholder('Sk-...')
+                            .setPlaceholder('sk-...')
                             .setValue(this.plugin.settings.apiKey || '')
                             .onChange(async (value) => {
                                 this.plugin.settings.apiKey = value;


### PR DESCRIPTION
Match the OpenAI API key placeholders to the actual lowercase sk- prefix in the settings UI.