### PR TITLE
fix: address Obsidian review bot settings copy

### DIFF
--- a/src/ui/settings/SettingsTab.ts
+++ b/src/ui/settings/SettingsTab.ts
@@ -48,9 +48,7 @@ export class SettingsTab extends PluginSettingTab {
         containerEl.empty();
         containerEl.addClass('speech-to-text-settings');
 
-        // Add main title
-        new Setting(containerEl).setName('Speech to text').setHeading();
-        this.debug('Title setting created');
+        this.debug('Using plugin settings container without a duplicate title heading');
 
         // Add debug info section at the top
         const debugSection = containerEl.createEl('details', { cls: 'speech-to-text-debug' });
@@ -309,7 +307,7 @@ export class SettingsTab extends PluginSettingTab {
     }
 
     private renderWhisperSettings(containerEl: HTMLElement): void {
-        new Setting(containerEl).setName('General transcription').setHeading();
+        new Setting(containerEl).setName('Transcription defaults').setHeading();
 
         // Whisper API Key
         this.renderWhisperApiKey(containerEl);

--- a/src/ui/settings/components/AudioSettings.ts
+++ b/src/ui/settings/components/AudioSettings.ts
@@ -100,7 +100,7 @@ export class AudioSettings {
             .setDesc('Enter an optional prompt to guide speech recognition')
             .addTextArea((text) =>
                 text
-                    .setPlaceholder('Example: This recording contains medical terminology.')
+                    .setPlaceholder('For example: this recording contains medical terminology.')
                     .setValue(this.plugin.settings.prompt || '')
                     .onChange(async (value) => {
                         this.plugin.settings.prompt = value;


### PR DESCRIPTION
## Summary
- remove the duplicate plugin-name heading from the settings tab
- rename the transcription section to avoid a "General" heading
- update the custom prompt placeholder to sentence case

## Validation
- npx eslint src/ui/settings/SettingsTab.ts src/ui/settings/components/AudioSettings.ts
- npm run typecheck