### PR TITLE
style: fix code quality formatting after #84

### DIFF
--- a/src/__tests__/notifications/NotificationManager.test.ts
+++ b/src/__tests__/notifications/NotificationManager.test.ts
@@ -130,7 +130,9 @@ describe('NotificationManager', () => {
 
             // DOM에서 확인 버튼 찾기
             setTimeout(() => {
-                const confirmBtn = document.querySelector('.sn-modal__action--primary') as HTMLElement;
+                const confirmBtn = document.querySelector(
+                    '.sn-modal__action--primary'
+                ) as HTMLElement;
                 confirmBtn?.click();
             }, 10);
 

--- a/src/ui/components/DragDropZone.ts
+++ b/src/ui/components/DragDropZone.ts
@@ -324,7 +324,9 @@ export class DragDropZone {
     private showMessage(message: string, type: 'success' | 'error') {
         if (!this.dropZone) return;
 
-        const messageEl = this.dropZone.createDiv(`sn-drop-zone-message sn-drop-zone-message--${type}`);
+        const messageEl = this.dropZone.createDiv(
+            `sn-drop-zone-message sn-drop-zone-message--${type}`
+        );
         messageEl.setText(message);
 
         setTimeout(() => {

--- a/src/ui/dashboard/StatisticsDashboard.ts
+++ b/src/ui/dashboard/StatisticsDashboard.ts
@@ -457,7 +457,9 @@ export class StatisticsDashboard {
         };
 
         Object.entries(updates).forEach(([id, value]) => {
-            const card = this.element?.querySelector(`[data-stat-id="${id}"] .sn-stats-card__value`);
+            const card = this.element?.querySelector(
+                `[data-stat-id="${id}"] .sn-stats-card__value`
+            );
             if (card) {
                 card.textContent = value;
             }


### PR DESCRIPTION
## Summary
- apply Prettier formatting to the 3 files that caused the Code Quality Check to fail in the follow-up branch for PR #84
- keep the change set limited to formatting only

## Context
PR #84 was merged before the failing formatting check was corrected.
This follow-up PR brings the formatting-only fix onto `main`.

Failing run:
https://github.com/asyouplz/SpeechNote/actions/runs/23278508815

## Validation
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
